### PR TITLE
MovieList: Fix renaming

### DIFF
--- a/lib/python/Screens/MovieSelection.py
+++ b/lib/python/Screens/MovieSelection.py
@@ -1672,16 +1672,18 @@ class MovieSelection(Screen, HelpableScreen, SelectionEventInfo, InfoBarBase, Pr
 		recording.setAutoincreaseEnd()
 		self.session.nav.RecordTimer.record(recording, ignoreTSC = True)
 
-	def renameCallback(self, name):
-		if not name:
+	def renameCallback(self, newname):
+		if not newname:
 			return
-		name = "".join((name.strip(), self.extension))
 		item = self.getCurrentSelection()
+		newbasename = newname.strip()
 		if item and item[0]:
 			try:
-				path = item[0].getPath().rstrip('/')
-				meta = path + '.meta'
+				oldfilename = item[0].getPath().rstrip('/')
+				meta = oldfilename + '.meta'
 				if os.path.isfile(meta):
+					# if .meta file is present don't rename files. Only set new name in .meta
+					name = "".join((newbasename, self.extension))
 					metafile = open(meta, "r+")
 					sid = metafile.readline()
 					oldtitle = metafile.readline()
@@ -1697,18 +1699,35 @@ class MovieSelection(Screen, HelpableScreen, SelectionEventInfo, InfoBarBase, Pr
 					else:
 						self.list.invalidateCurrentItem()
 					return
-				pathname,filename = os.path.split(path)
-				newpath = os.path.join(pathname, name)
+				# rename all files
 				msg = None
-				print "[ML] rename", path, "to", newpath
-				os.rename(path, newpath)
-				self.reloadList(sel = eServiceReference("2:0:1:0:0:0:0:0:0:0:" + newpath))
+				path,filename = os.path.split(oldfilename)
+				if item[0].flags & eServiceReference.mustDescent: # directory
+					newfilename = os.path.join(path, newbasename)
+					print "[ML] rename dir", oldfilename, "to", newfilename
+					os.rename(oldfilename, newfilename)
+				else:
+					if oldfilename.endswith(self.extension):
+						oldbasename = oldfilename[:-len(self.extension)]
+					renamelist = []
+					dont_rename = False
+					for ext in ('.eit', self.extension + '.cuts', self.extension):
+						newfilename = os.path.join(path, newbasename) + ext
+						oldfilename = os.path.join(path, oldbasename) + ext
+						if not os.path.isfile(newfilename):
+							renamelist.append((oldfilename, newfilename))
+						else:
+							msg = _("The path %s already exists.") % newname
+							dont_rename = True
+							break
+					if not dont_rename:
+						for r in renamelist:
+							print "[ML] rename", r[0], "to", r[1]
+							os.rename(r[0], r[1])
+				self.reloadList(sel = eServiceReference("2:0:1:0:0:0:0:0:0:0:" + newfilename))
 			except OSError, e:
 				print "Error %s:" % e.errno, e
-				if e.errno == 17:
-					msg = _("The path %s already exists.") % name
-				else:
-					msg = _("Error") + '\n' + str(e)
+				msg = _("Error") + '\n' + str(e)
 			except Exception, e:
 				import traceback
 				print "[ML] Unexpected error:", e


### PR DESCRIPTION
A rename has to process all affected files. .cuts and .eit files
were missing. This could lead to strange effects for the user as
e.g. .cuts files with old names are not visible in the movielist.