### PR TITLE
[skin.py] Experimental removal of SD and old skins

### DIFF
--- a/skin.py
+++ b/skin.py
@@ -14,14 +14,13 @@ from Tools.Directories import SCOPE_CONFIG, SCOPE_CURRENT_LCDSKIN, SCOPE_CURRENT
 from Tools.Import import my_import
 from Tools.LoadPixmap import LoadPixmap
 
-DEFAULT_SKIN = SystemInfo["HasFullHDSkinSupport"] and "PLi-FullNightHD/skin.xml" or "PLi-HD/skin.xml"  # On SD hardware PLi-HD will not be available.
-DEFAULT_SD_SKIN = "Magic/skin.xml"
+DEFAULT_SKIN = SystemInfo["HasFullHDSkinSupport"] and "PLi-FullNightHD/skin.xml" or "PLi-HD/skin.xml"  # SD hardware is no longer supported by the default skin.
 EMERGENCY_SKIN = "skin_default.xml"
 DEFAULT_DISPLAY_SKIN = "skin_display.xml"
 USER_SKIN = "skin_user.xml"
 USER_SKIN_TEMPLATE = "skin_user_%s.xml"
-BOX_SKIN = "skin_box.xml"  # DEBUG: Is this actually used?
-SECOND_INFOBAR_SKIN = "skin_second_infobar.xml"  # DEBUG: Is this actually used?
+# BOX_SKIN = "skin_box.xml"  # DEBUG: Is this actually used?
+# SECOND_INFOBAR_SKIN = "skin_second_infobar.xml"  # DEBUG: Is this actually used?
 SUBTITLE_SKIN = "skin_subtitles.xml"
 
 GUI_SKIN_ID = 0  # Main frame-buffer.
@@ -55,16 +54,10 @@ fonts = {  # Dictionary of predefined and skin defined font aliases.
 # E.g. "MySkin/skin_display.xml"
 #
 config.skin = ConfigSubsection()
-# On SD hardware, DEFAULT_SKIN will not be available.
 skin = resolveFilename(SCOPE_SKIN, DEFAULT_SKIN)
 if not fileExists(skin) or not os.path.isfile(skin):
-	# In that case, fallback to the DEFAULT_SD_SKIN.
-	DEFAULT_SKIN = DEFAULT_SD_SKIN
-	print "[Skin] Error: Default HD skin '%s' is not readable or is not a file!  Using default SD skin." % skin
-	skin = resolveFilename(SCOPE_SKIN, DEFAULT_SKIN)
-	if not fileExists(skin) or not os.path.isfile(skin):
-		DEFAULT_SKIN = "skin.xml"
-		print "[Skin] Error: Default SD skin '%s' is not also readable or is not a file!  Using emergency skin." % skin
+	print "[Skin] Error: Default skin '%s' is not readable or is not a file!  Using emergency skin." % skin
+	DEFAULT_SKIN = EMERGENCY_SKIN
 config.skin.primary_skin = ConfigText(default=DEFAULT_SKIN)
 config.skin.display_skin = ConfigText(default=DEFAULT_DISPLAY_SKIN)
 


### PR DESCRIPTION
This commit is an experiment to test if the old SD default / OoB skin is stall actually being used or is still required.

This commit also tests the impact of removing the "skin_box.xml" and "skin_second_infobar.xml" skins.  It is believed that these skins are no longer used.  This test removal should prove the point.

If there are any issues for developers or users please immediately revert this commit and discuss the issues with me.