### PR TITLE
Multiboot: use list on PosixSpawn arguments

### DIFF
--- a/lib/python/Tools/Multiboot.py
+++ b/lib/python/Tools/Multiboot.py
@@ -18,7 +18,7 @@ def getMultibootslots():
 		if not os.path.isdir(TMP_MOUNT):
 			os.mkdir(TMP_MOUNT)
 		postix = PosixSpawn()
-		postix.execute('mount %s %s' % (SystemInfo["MultibootStartupDevice"], TMP_MOUNT))
+		postix.execute('/bin/mount', [SystemInfo["MultibootStartupDevice"], TMP_MOUNT])
 		for file in glob.glob('%s/STARTUP_*' % TMP_MOUNT):
 			slotnumber = file.rsplit('_', 3 if 'BOXMODE' in file else 1)[1]
 			if slotnumber.isdigit() and slotnumber not in bootslots:
@@ -34,7 +34,7 @@ def getMultibootslots():
 						break
 				if slot:
 					bootslots[int(slotnumber)] = slot
-		postix.execute('umount %s' % TMP_MOUNT)
+		postix.execute('/bin/umount', [TMP_MOUNT])
 		if not os.path.ismount(TMP_MOUNT):
 			os.rmdir(TMP_MOUNT)
 	return bootslots


### PR DESCRIPTION
The execute function of PosixSpawn class seems to require arguments passed as list.
Also it seems to require the full path to executable.

Please note that this function is interacting directly with libc using ctypes, so "extra" work seem to required
in order to properly execute binaries.

Moving on Python 3.8 there is native support for posix_spawn (vfork) so embedded systems can benefit from such change.