### PR TITLE
[SystemInfo.py] Restore previous cmdline processing

### DIFF
--- a/lib/python/Components/SystemInfo.py
+++ b/lib/python/Components/SystemInfo.py
@@ -12,9 +12,7 @@ from Tools.Multiboot import getMultibootStartupDevice, getMultibootslots  # This
 
 # Parse the boot commandline.
 #
-fd = open("/proc/cmdline", "r")
-cmdline = fd.read()
-fd.close()
+cmdline = open("/proc/cmdline", "r").read()
 cmdline = {k: v.strip('"') for k, v in re.findall(r'(\S+)=(".*?"|\S+)', cmdline)}
 
 def getNumVideoDecoders():


### PR DESCRIPTION
This change reverts the change to reading the cmdline.  An open().read() has an implied close() so that an explicit close is not required.