### PR TITLE
Revert "eEPGCache: Try to make load/save epg.dat thread prove"

### DIFF
--- a/lib/dvb/epgcache.h
+++ b/lib/dvb/epgcache.h
@@ -352,8 +352,7 @@ private:
 #endif // SWIG
 public:
 	static eEPGCache *getInstance() { return instance; }
-	void restartAllChannelsEPG();
-	void abortAllChannelsEPG();
+
 	void save();
 	void load();
 	void timeUpdated();


### PR DESCRIPTION
This reverts commit 9d9cc35aa1815ae535d75cc8f4068552c2ac25c5.

As it does crash when having a rotor... the service is not always already tuned so startEPG may not work

Thanks for reporting IMS... more investigation is required...

[eEPGCache] abort All Channels EPG
[eEPGCache] stop caching events(890)
[eEPGCache] 125906 events read from /hdd/epg.dat
[eEPGCache] restart All Channels EPG
[eEPGCache] start caching events(890)
Backtrace:
/usr/bin/enigma2(handleFatalSignal(int, siginfo_t*, void*)) [0xD424C]
/lib/libc.so.6(__default_rt_sa_restorer) [0xB6C99C60]
/usr/bin/enigma2(eEPGCache::channel_data::cleanupOPENTV()) [0xDE220]
/usr/bin/enigma2(eEPGCache::channel_data::startEPG()) [0x9A988]
/usr/bin/enigma2(eEPGCache::restartAllChannelsEPG()) [0x9BE64]
/usr/bin/enigma2(eEPGCache::load()) [0x9C7C0]
/usr/bin/enigma2(n/a) [0x1176D4]
-------FATAL SIGNAL