### PR TITLE
Add debug output to listbox python buildfunc calls

### DIFF
--- a/lib/gui/elistboxcontent.cpp
+++ b/lib/gui/elistboxcontent.cpp
@@ -798,6 +798,7 @@ void eListboxPythonMultiContent::paint(gPainter &painter, eWindowStyle &style, c
 
 		if (!items)
 		{
+			PyErr_Print();
 			eDebug("[eListboxPythonMultiContent] error getting item %d", m_cursor);
 			goto error_out;
 		}

--- a/lib/python/Screens/Hotkey.py
+++ b/lib/python/Screens/Hotkey.py
@@ -640,8 +640,10 @@ class InfoBarHotkey():
 				try:
 					exec "from %s import %s" % (selected[1], selected[2])
 					exec "self.session.open(%s)" %  ",".join(selected[2:])
-				except:
-					print "[Hotkey] error during executing module %s, screen %s" % (selected[1], selected[2])
+				except Exception as e:
+					print "[Hotkey] error during executing module %s, screen %s, %s" % (selected[1], selected[2], e)					
+					import traceback
+					traceback.print_exc()
 			elif selected[0] == "SoftcamSetup" and SystemInfo["HasSoftcamInstalled"]:
 				from Screens.SoftcamSetup import SoftcamSetup
 				self.session.open(SoftcamSetup)


### PR DESCRIPTION
This change adds exception stack output
when a Python buildfunc throws an exception
when a button press that opens a screen throws an exception

By @simoncapewell