### PR TITLE
Revert "Add keytranslation.xml"

### DIFF
--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -8,7 +8,6 @@ dist_pkgdata_DATA = \
 	groupedservices \
 	iso-639-3.pck \
 	keymap.xml \
-	keytranslation.xml \
 	menu.xml \
 	otv_00820000_fbff_16a8.dict \
 	otv_011a0000_0002_07d4.dict \

--- a/data/keytranslation.xml
+++ b/data/keytranslation.xml
@@ -1,7 +1,0 @@
-<keymap>
-	<translate>
-		<device name="gigablue remote control">
-			<key from="KEY_OPTION" to="KEY_HELP"/>
-		</device>
-	</translate>
-</keymap>


### PR DESCRIPTION
This reverts part of commit 243a2af8396a3b197374ebf49241db1c4351a390.

keytranslation.xml is a user-defined file, manufacturing errors in
keymaps should be fixed by the manufacturer, not worked around.