### PR TITLE
[epgcache.cpp] "m_OPENTV_EIT_map.erase(it)" removed for further testi…

### DIFF
--- a/lib/dvb/epgcache.cpp
+++ b/lib/dvb/epgcache.cpp
@@ -2059,7 +2059,7 @@ void eEPGCache::channel_data::OPENTV_checkCompletion(uint32_t data_crc)
 				sids.push_back(m_OPENTV_channels_map[channelid].serviceId);
 				cache->submitEventData(sids, chids, it->second.startTime, it->second.duration, m_OPENTV_descriptors_map[it->second.title_crc].c_str(), "", "", 0, eEPGCache::OPENTV);
 			}
-			m_OPENTV_EIT_map.erase(it);
+			// m_OPENTV_EIT_map.erase(it); // removed for further testing due to seg fault, endless spinner and blocking issues
 		}
 		m_OPENTV_descriptors_map.clear();
 


### PR DESCRIPTION
…ng due to seg fault, endless spinner and blocking issues