### PR TITLE
[Source.py] Match message to skin

### DIFF
--- a/lib/python/Components/Sources/Source.py
+++ b/lib/python/Components/Sources/Source.py
@@ -1,5 +1,6 @@
 from Components.Element import Element
 
+
 class Source(Element):
 	def execBegin(self):
 		pass
@@ -16,8 +17,9 @@ class Source(Element):
 	def destroy(self):
 		self.__dict__.clear()
 
+
 class ObsoleteSource(Source):
-	def __init__(self, new_source, description = None, removal_date = "as soon as possible"):
-		self.new_source = new_source
+	def __init__(self, newSource, description=None, removalDate="AS SOON AS POSSIBLE"):
+		self.newSource = newSource
 		self.description = description
-		self.removal_date = removal_date
+		self.removalDate = removalDate


### PR DESCRIPTION
- Match removal message to match style used in skin.py.
- Use camelCase for variables.  (ObsoleteSource class does not appear to be used.)
- PEP8 clean up.