### PR TITLE
font: AddFont change eFatal into eWarning

### DIFF
--- a/lib/gdi/font.cpp
+++ b/lib/gdi/font.cpp
@@ -151,23 +151,25 @@ std::string fontRenderClass::AddFont(const std::string &filename, const std::str
 {
 	eDebugNoNewLineStart("[Font] Adding font '%s'", filename.c_str());
 	int error;
-	fontListEntry *n=new fontListEntry;
-
-	n->scale=scale;
 	FT_Face face;
+
 	singleLock s(ftlock);
-
 	if ((error=FT_New_Face(library, filename.c_str(), 0, &face)))
-		eFatal("[Font] Failed: %m");
-
-	n->filename=filename;
-	n->face=name;
-	n->renderflags=renderflags;
+	{
+		eWarning("[Font] Failed: %m");
+		return std::string();
+	}
 	FT_Done_Face(face);
 
+	fontListEntry *n = new fontListEntry;
+	n->filename = filename;
+	n->face = name;
+	n->scale = scale;
+	n->renderflags = renderflags;
 	n->next=font;
-	eDebugNoNewLine(" -> '%s'.\n", n->face.c_str());
 	font=n;
+
+	eDebug(" -> '%s'.", n->face.c_str());
 
 	return n->face;
 }


### PR DESCRIPTION
AddFont should forgive some errors, eg a missing font due to wrong filename.
Change eFatal into eWarning and reogranize the code for better readability.