### PR TITLE
sf8008/trio4k: Don't allow flashing images on SD card

### DIFF
--- a/lib/python/Screens/FlashImage.py
+++ b/lib/python/Screens/FlashImage.py
@@ -225,9 +225,10 @@ class FlashImage(Screen):
 		self.getImageList = None
 		choices = []
 		currentimageslot = GetCurrentImage()
-		for x in range(1, len(SystemInfo["canMultiBoot"]) + 1):
+		slotdict = { k:v for k, v in SystemInfo["canMultiBoot"].items() if not v['device'].startswith('/dev/sda')}
+		for x in range(1, len(slotdict) + 1):
 			choices.append(((_("slot%s - %s (current image) with, backup") if x == currentimageslot else _("slot%s - %s, with backup")) % (x, imagedict[x]['imagename']), (x, "with backup")))
-		for x in range(1, len(SystemInfo["canMultiBoot"]) + 1):
+		for x in range(1, len(slotdict) + 1):
 			choices.append(((_("slot%s - %s (current image), without backup") if x == currentimageslot else _("slot%s - %s, without backup")) % (x, imagedict[x]['imagename']), (x, "without backup")))
 		choices.append((_("No, do not flash image"), False))
 		self.session.openWithCallback(self.checkMedia, MessageBox, self.message, list=choices, default=currentimageslot, simple=True)


### PR DESCRIPTION
PLi e2 version with current ofgwrite cannot flash images on
SD cards without workarounds. Flashing images on SD cards will be
disabled until this is fixed.