### PR TITLE
[Renderer.Label] Sanity test

### DIFF
--- a/lib/python/Components/Renderer/Label.py
+++ b/lib/python/Components/Renderer/Label.py
@@ -21,7 +21,8 @@ class Label(VariableText, Renderer):
 		if what[0] == self.CHANGED_CLEAR:
 			self.text = ""
 		elif self.source:
-			self.text = self.source.text
+			if hasattr(self.source, "text"):
+				self.text = self.source.text
 		else:
 			self.text = "<No Source>"
 			print "SKINERROR: render label has no source"


### PR DESCRIPTION
This allows Label() to be used with non-text Sources

Fixes a bug with Renderer.Label when it tries to access source.text
when the upstream has no text attribute.

For example, in ViX-Common skin (used by ViX-Night-HD and ViX-Day-HD
skins) widget if you use this:

<widget source="VKeyIcon" conditional="VKeyIcon" render="Label" text="TEXT" position="1200,686" zPosition="1" size="35,25" transparent="1" alphatest="on">
	<convert type="ConditionalShowHide"/>
</widget>

Instead of the corresponding widget with a Pixmap renderer in
FullscreenConfigPanel, the TEXT label never displays and an exception
is thrown in the skin code "Error in screen 'Setup': 'ConditionalShowHide'
object has no attribute 'text'".

This changes Label.changed() to only try to access self.source.text if
the text attribute exists.

Author: @prl001