### PR TITLE
For multiboot do not rmtree to avoid 'softbrick' boxes

### DIFF
--- a/lib/python/Screens/FlashImage.py
+++ b/lib/python/Screens/FlashImage.py
@@ -435,7 +435,8 @@ class MultibootSelection(SelectImage):
 
 	def unmountCallback(self, value, data=None, retval=None, extra_args=None):
 		self.container.killAll()
-		shutil.rmtree(self.tmp_dir, True)
+		if not os.path.ismount(self.tmp_dir):
+			os.rmdir(self.tmp_dir)
 		if value == 2:
 			from Screens.Standby import TryQuitMainloop
 			self.session.open(TryQuitMainloop, 2)

--- a/lib/python/Tools/Multiboot.py
+++ b/lib/python/Tools/Multiboot.py
@@ -1,6 +1,6 @@
 from Components.SystemInfo import SystemInfo
 from Components.Console import Console
-import os, glob, tempfile, shutil
+import os, glob, tempfile
 
 class tmp:
 	dir = None
@@ -14,7 +14,8 @@ def getMultibootStartupDevice():
 				print '[Multiboot] Startupdevice found:', device
 				return device
 			Console().ePopen('umount %s' % tmp.dir)
-	shutil.rmtree(tmp.dir, True)
+	if not os.path.ismount(tmp.dir):
+		os.rmdir(tmp.dir)
 
 def getparam(line, param):
 	return line.rsplit('%s=' % param, 1)[1].split(' ', 1)[0]
@@ -43,7 +44,8 @@ def getMultibootslots():
 				if slot:
 					bootslots[int(slotnumber)] = slot
 		Console().ePopen('umount %s' % tmp.dir)
-		shutil.rmtree(tmp.dir, True)
+		if not os.path.ismount(tmp.dir):
+			os.rmdir(tmp.dir)
 		if not mode12found and SystemInfo["canMode12"]:
 			#the boot device has ancient content and does not contain the correct STARTUP files
 			for slot in range(1,5):
@@ -116,5 +118,6 @@ class GetImagelist():
 			self.run()
 		else:
 			self.container.killAll()
-			shutil.rmtree(self.tmp_mount, True)
+			if not os.path.ismount(self.tmp_mount):
+				os.rmdir(self.tmp_mount)
 			self.callback(self.imagelist)


### PR DESCRIPTION
When by accident the partition is still mounted it could remove full
images and/or the STARTUP files that 'softbrick' the boxes. You need to
reinstall images and/or the recovery image. This avoids it in case
something odd happens. Then better get a GSOD instead of 'softbrick' a
box