### PR TITLE
Update unicable.xml

### DIFF
--- a/data/unicable.xml
+++ b/data/unicable.xml
@@ -201,52 +201,12 @@
 			<product name="9762I" format="jess" positions="4" scrs="1210,1420,1680"/>
 		</manufacturer>
 		<manufacturer name="JULTEC">
-			<product name="JPS0501-12" format="jess" scrs="974,1076,1178,1280,1382,1484,1586,1688,1790,1892,1994,2096"/>
-			<product name="JPS0501-8(A/M/T)" format="jess" scrs="1076,1178,1280,1382,1484,1586,1688,1790"/>
-			<product name="JPS0501-6" format="jess" scrs="1280,1382,1484,1586,1688,1790"/>
-			<product name="JPS0502-3" format="jess" scrs="1280,1382,1484"/>
-			<product name="JPS0502-6" format="jess" scrs="1280,1382,1484,1586,1688,1790"/>
-			<product name="JPS0502-3(A/T)" format="jess" scrs="1280,1382,1484"/>
-			<product name="JPS0502-6(M/T)" format="jess" scrs="1280,1382,1484,1586,1688,1790"/>
-			<product name="JPS0504-3(A/T)" format="jess" scrs="1280,1382,1484"/>
-			<product name="JPS0504-6(M/T)" format="jess" scrs="1280,1382,1484,1586,1688,1790"/>
-			<product name="JRS0504-2(A/T)" format="jess" scrs="1280,1382"/>
-			<product name="JPS0506-3(A/T)" format="jess" scrs="1280,1382,1484"/>
-			<product name="JPS0508-3(A/M/T)" format="jess" scrs="1280,1382,1484"/>
-			<product name="JRS0502-2+4(T)" format="jess" scrs="1280,1382"/>
-			<product name="JRS0502-8+4T" format="jess" scrs="1375,1425,1475,1525,1575,1625,1675,1725"/>
-			<product name="old JRS0502-2+4" scrs="1280,1382"/>
-			<product name="JRS0504-2" format="jess" scrs="1280,1382"/>
-			<product name="JPS0502-4(M/T)" format="jess" scrs="1375,1425,1475,1525"/>
-			<product name="JPSxx/JRSxx mit 4 UB" format="jess" scrs="1375,1425,1475,1525"/>
-			<product name="JPSxx/JRSxx mit 8 UB" format="jess" scrs="1375,1425,1475,1525,1575,1625,1675,1725"/>
-			<product name="JPSxx/JRSxx mit 16 UB" format="jess" scrs="1375,1425,1475,1525,1575,1625,1675,1725,1775,1825,1875,1925,1975,2025,2075,2125"/>
-			<product name="JPS0901-6(A/M/T)" positions="2" format="jess" scrs="1280,1382,1484,1586,1688,1790"/>
-			<product name="JPS0901-12(AN/TN)" positions="2" format="jess" scrs="974,1076,1178,1280,1382,1484,1586,1688,1790,1892,1994,2096"/>
-			<product name="JPS0902-12(MN/TN)" positions="2" format="jess" scrs="974,1076,1178,1280,1382,1484,1586,1688,1790,1892,1994,2096"/>
-			<product name="JPS0902-3" positions="2" format="jess" scrs="1280,1382,1484"/>
-			<product name="JPS0902-6(A/M/T)" positions="2" format="jess" scrs="1280,1382,1484,1586,1688,1790"/>
-			<product name="JPS0904-3(A/M/T)" positions="2" format="jess" scrs="1280,1382,1484"/>
-			<product name="JPS0904-6(M/T)" positions="2" format="jess" scrs="1280,1382,1484,1586,1688,1790"/>
-			<product name="JPS0906-3(A/M/T)" positions="2" format="jess" scrs="1280,1382,1484"/>
-			<product name="JPS0908-3(A/M/T)" positions="2" format="jess" scrs="1280,1382,1484"/>
-			<product name="JRS0902-2+4(T)" positions="2" format="jess" scrs="1280,1382"/>
-			<product name="JRS0904-2(A/T)" positions="2" format="jess" scrs="1280,1382"/>
-			<product name="JPS1701-12(AN/TN)" positions="4" format="jess" scrs="974,1076,1178,1280,1382,1484,1586,1688,1790,1892,1994,2096"/>
-			<product name="JPS1702-12(AN/TN)" positions="4" format="jess" scrs="974,1076,1178,1280,1382,1484,1586,1688,1790,1892,1994,2096"/>
-			<product name="JPS1702-6(A/M/T)" positions="4" format="jess" scrs="1280,1382,1484,1586,1688,1790"/>
-			<product name="JPS1704-3(A/M/T)" positions="4" format="jess" scrs="1280,1382,1484"/>
-			<product name="JPS1704-6(M/T)" positions="4" format="jess" scrs="1280,1382,1484,1586,1688,1790"/>
-			<product name="JPS1706-3(A/M/T)" positions="4" format="jess" scrs="1280,1382,1484"/>
-			<product name="JPS1708-3(A/M/T)" positions="4" format="jess" scrs="1280,1382,1484"/>
-			<product name="JPS1701-12 (EFGH)" positions="4" positionsoffset="4" format="jess" scrs="974,1076,1178,1280,1382,1484,1586,1688,1790,1892,1994,2096"/>
-			<product name="JPS1702-12 (EFGH)" positions="4" positionsoffset="4" format="jess" scrs="974,1076,1178,1280,1382,1484,1586,1688,1790,1892,1994,2096"/>
-			<product name="JPS1702-6 (EFGH)" positions="4" positionsoffset="4" format="jess" scrs="1280,1382,1484,1586,1688,1790"/>
-			<product name="JPS1704-3 (EFGH)" positions="4" positionsoffset="4" format="jess" scrs="1280,1382,1484"/>
-			<product name="JPS1704-6 (EFGH)" positions="4" positionsoffset="4" format="jess" scrs="1280,1382,1484,1586,1688,1790"/>
-			<product name="JPS1706-3 (EFGH)" positions="4" positionsoffset="4" format="jess" scrs="1280,1382,1484"/>
-			<product name="JPS1708-3 (EFGH)" positions="4" positionsoffset="4" format="jess" scrs="1280,1382,1484"/>
-		</manufacturer>
+			<product name="JPSxx/JRSxx 3 UB" positions="8" format="jess" scrs="1280,1382,1484"/>
+			<product name="JPSxx/JRSxx 4 UB" positions="8" format="jess" scrs="1375,1425,1475,1525"/>
+			<product name="JPSxx/JRSxx 6 UB" positions="8" format="jess" scrs="1280,1382,1484,1586,1688,1790"/>
+			<product name="JPSxx/JRSxx 8 UB" positions="8" format="jess" scrs="1375,1425,1475,1525,1575,1625,1675,1725"/>
+			<product name="JPSxx/JRSxx 12 UB" positions="8" format="jess" scrs="974,1076,1178,1280,1382,1484,1586,1688,1790,1892,1994,2096"/>
+			<product name="JPSxx/JRSxx 16 UB" positions="8" format="jess" scrs="1375,1425,1475,1525,1575,1625,1675,1725,1775,1825,1875,1925,1975,2025,2075,2125"/>		</manufacturer>
 		<manufacturer name="Kathrein">
 			<product name="EXR501" scrs="1400,1516,1632,1748"/>
 			<product name="EXR551" scrs="1400,1516,1632,1748"/>


### PR DESCRIPTION
Simplified choices for JULTEC switches, the only difference between the different products of JULTEC is the number of positions and the used UB (Userbands), by having the choice for 3,4,6,8,12,16 UB settings it should be able to use all JULTEC products