### PR TITLE
Network: use netifaces library to read network settings

### DIFF
--- a/lib/python/Components/Network.py
+++ b/lib/python/Components/Network.py
@@ -1,5 +1,6 @@
 import os
 import re
+import netifaces as ni
 from socket import *
 from Components.Console import Console
 from Components.PluginComponent import plugins
@@ -61,70 +62,22 @@ class Network:
 		return [ int(n) for n in ip.split('.') ]
 
 	def getAddrInet(self, iface, callback):
-		cmd = ("/sbin/ip", "/sbin/ip", "-o", "addr", "show", "dev", iface)
-		self.console.ePopen(cmd, self.IPaddrFinished, [iface, callback])
-
-	def IPaddrFinished(self, result, retval, extra_args):
-		(iface, callback ) = extra_args
 		data = { 'up': False, 'dhcp': False, 'preup' : False, 'predown' : False }
-		globalIPpattern = re.compile("scope global")
-		ipRegexp = '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}'
-		netRegexp = '[0-9]{1,2}'
-		macRegexp = '[0-9a-fA-F]{2}\:[0-9a-fA-F]{2}\:[0-9a-fA-F]{2}\:[0-9a-fA-F]{2}\:[0-9a-fA-F]{2}\:[0-9a-fA-F]{2}'
-		ipLinePattern = re.compile('inet ' + ipRegexp + '/')
-		ipPattern = re.compile(ipRegexp)
-		netmaskLinePattern = re.compile('/' + netRegexp)
-		netmaskPattern = re.compile(netRegexp)
-		bcastLinePattern = re.compile(' brd ' + ipRegexp)
-		upPattern = re.compile('UP')
-		macPattern = re.compile(macRegexp)
-		macLinePattern = re.compile('link/ether ' + macRegexp)
-
-		for line in result.splitlines():
-			split = line.strip().split(' ',2)
-			if (split[1][:-1] == iface) or (split[1][:-1] == (iface + '@sys0')):
-				up = self.regExpMatch(upPattern, split[2])
-				mac = self.regExpMatch(macPattern, self.regExpMatch(macLinePattern, split[2]))
-				if up is not None:
-					data['up'] = True
-					if iface is not 'lo':
-						self.configuredInterfaces.append(iface)
-				if mac is not None:
-					data['mac'] = mac
-			if split[1] == iface:
-				if re.search(globalIPpattern, split[2]):
-					ip = self.regExpMatch(ipPattern, self.regExpMatch(ipLinePattern, split[2]))
-					netmask = self.calc_netmask(self.regExpMatch(netmaskPattern, self.regExpMatch(netmaskLinePattern, split[2])))
-					bcast = self.regExpMatch(ipPattern, self.regExpMatch(bcastLinePattern, split[2]))
-					if ip is not None:
-						data['ip'] = self.convertIP(ip)
-					if netmask is not None:
-						data['netmask'] = self.convertIP(netmask)
-					if bcast is not None:
-						data['bcast'] = self.convertIP(bcast)
-
-		if 'ip' not in data:
+		try:
+			data['up'] = int(open('/sys/class/net/%s/flags' % iface).read().strip(), 16) & 1 == 1
+			if data['up']:
+				self.configuredInterfaces.append(iface)
+			nit = ni.ifaddresses(iface)
+			data['ip'] = self.convertIP(nit[ni.AF_INET][0]['addr']) # ipv4
+			data['netmask'] = self.convertIP(nit[ni.AF_INET][0]['netmask'])
+			data['bcast'] = self.convertIP(nit[ni.AF_INET][0]['broadcast'])
+			data['mac'] = nit[ni.AF_LINK][0]['addr'] # mac
+			data['gateway'] = self.convertIP(ni.gateways()['default'][ni.AF_INET][0]) # default gw
+		except:
 			data['dhcp'] = True
 			data['ip'] = [0, 0, 0, 0]
 			data['netmask'] = [0, 0, 0, 0]
 			data['gateway'] = [0, 0, 0, 0]
-
-		cmd = "route -n | grep " + iface
-		self.console.ePopen(cmd,self.routeFinished, [iface, data, callback])
-
-	def routeFinished(self, result, retval, extra_args):
-		(iface, data, callback) = extra_args
-		ipRegexp = '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}'
-		ipPattern = re.compile(ipRegexp)
-		ipLinePattern = re.compile(ipRegexp)
-
-		for line in result.splitlines():
-			print line[0:7]
-			if line[0:7] == "0.0.0.0":
-				gateway = self.regExpMatch(ipPattern, line[16:31])
-				if gateway:
-					data['gateway'] = self.convertIP(gateway)
-
 		self.ifaces[iface] = data
 		self.loadNetworkConfig(iface,callback)
 


### PR DESCRIPTION
This commit uses the netifaces python library to read the network settings.
It seems to offer also a faster boot, when reading settings using netifaces.

It's so fast that OpenWebIf starts before enigma2 send the WHERE_NETWORKCONFIG_READ.