### PR TITLE
[Timezones.py] Correct "Canary" to "Canary Islands"

### DIFF
--- a/lib/python/Components/Timezones.py
+++ b/lib/python/Components/Timezones.py
@@ -123,6 +123,7 @@ class Timezones:
 		commonTimezoneNames = {
 			"Antarctica/DumontDUrville": "Dumont d'Urville",
 			"Asia/Ho_Chi_Minh": "Ho Chi Minh City",
+			"Atlantic/Canary": "Canary Islands",
 			"Australia/LHI": None,  # Duplicate entry - Exclude from list.
 			"Australia/Lord_Howe": "Lord Howe Island",
 			"Australia/North": "Northern Territory",


### PR DESCRIPTION
Correct the name of the Spanish archipelago from "Canary" to "Canary Islands".