### PR TITLE
estring - truncateUTF8 - cosmetic

### DIFF
--- a/lib/base/estring.cpp
+++ b/lib/base/estring.cpp
@@ -770,14 +770,14 @@ unsigned int truncateUTF8(std::string &s, unsigned int newsize)
 
 	if (len > idx){
 		while (idx > 0) {
-			if (s[idx] < 0x80 || (s[idx] & 0xc0) == 0xc0){
-				if (s[idx] < 0x80)
+			if (!s.at(idx) & 0x80 || (s.at(idx) & 0xc0) == 0xc0){
+				if (!s.at(idx) & 0x80)
 					idx++;
-				else if ((s[idx] & 0xF8) == 0xf0 && n == 3)
+				else if ((s.at(idx) & 0xF8) == 0xf0 && n == 3)
 					idx += n + 1;
-				else if ((s[idx] & 0xF0) == 0xe0 && n == 2)
+				else if ((s.at(idx) & 0xF0) == 0xe0 && n == 2)
 					idx += n + 1;
-				else if ((s[idx] & 0xE0) == 0xc0 && n == 1)
+				else if ((s.at(idx) & 0xE0) == 0xc0 && n == 1)
 					idx += n + 1;
 				break;
 			}


### PR DESCRIPTION
- used !(s[idx] & 0x80) instead of s[idx] < 80
- used s.at(idx) instead of s[idx]