### PR TITLE
[Screen.py] Revert hack and apply appropriate correction

### DIFF
--- a/lib/python/Screens/Screen.py
+++ b/lib/python/Screens/Screen.py
@@ -148,17 +148,18 @@ class Screen(dict):
 		try:  # This protects against calls to setTitle() before being fully initialised like self.session is accessed *before* being defined.
 			if self.session and len(self.session.dialog_stack) > 2:
 				self.screenPath = " > ".join(ds[0].getTitle() for ds in self.session.dialog_stack[2:])
+			else:
+				self.screenPath = ""
 			if self.instance:
 				self.instance.setTitle(title)
 			self.summaries.setTitle(title)
 		except AttributeError:
 			pass
 		self.screenTitle = title
-		dont_use_menu_path = "ChannelSelection" in self.__class__.__name__
-		if config.usage.menu_path.value == "large" and not dont_use_menu_path:
+		if config.usage.menu_path.value == "large":
 			screenPath = ""
 			screenTitle = "%s > %s" % (self.screenPath, title) if self.screenPath else title
-		elif config.usage.menu_path.value == "small" and not dont_use_menu_path:
+		elif config.usage.menu_path.value == "small":
 			screenPath = "%s >" % self.screenPath if self.screenPath else ""
 			screenTitle = title
 		else:
@@ -229,8 +230,8 @@ class Screen(dict):
 				if title:
 					self.skinAttributes[skinTitleIndex] = ("title", title)
 				else:
-					self["Title"].text = _(value)
-					self.summaries.setTitle(_(value))
+					self["Title"].text = value
+					self.summaries.setTitle(value)
 			elif key == "baseResolution":
 				baseRes = tuple([int(x) for x in value.split(",")])
 			idx += 1


### PR DESCRIPTION
- Revert the previous hack commit as it doesn't fix the problem.  It only hides it.
- Apply the appropriate correction to the screen path history buffer not being cleared when the screen path stack is cleared.