### PR TITLE
[unicable.xml] fix none scrs args

### DIFF
--- a/data/unicable.xml
+++ b/data/unicable.xml
@@ -272,7 +272,7 @@
 		</manufacturer>
 		<manufacturer name="ROTEK">
 			<product name="EKL2/1" scrs="1400,1516"/>
-			<product name="EKL2/1E,1632,1748"/>
+			<product name="EKL2/1E" scrs="1632,1748"/>
 		</manufacturer>
 		<manufacturer name="SetOne">
 			<product name="SCR 5/8" scrs="1284,1400,1516,1632,1748,1864,1980,2096"/>


### PR DESCRIPTION
File "/usr/lib/enigma2/python/Components/NimManager.py", line 1301, in
unicableProductChanged
    srcfrequencylist =
productparameters.get("scrs").split(",")
AttributeError: 'NoneType'
object has no attribute 'split'