### PR TITLE
[Satfinder] handle FAILED and LOSTLOCK

### DIFF
--- a/lib/python/Plugins/SystemPlugins/Satfinder/plugin.py
+++ b/lib/python/Plugins/SystemPlugins/Satfinder/plugin.py
@@ -1,4 +1,4 @@
-from enigma import eDVBResourceManager, eDVBFrontendParametersSatellite, eDVBFrontendParametersTerrestrial
+from enigma import eDVBResourceManager, eDVBFrontendParametersSatellite, eDVBFrontendParametersTerrestrial, eTimer
 
 from Screens.ScanSetup import ScanSetup, buildTerTransponder
 from Screens.ServiceScan import ServiceScan
@@ -56,6 +56,8 @@ class Satfinder(ScanSetup, ServiceScan):
 		self.session.postScanService = self.session.nav.getCurrentlyPlayingServiceOrGroup()
 		self.onClose.append(self.__onClose)
 		self.onShow.append(self.prepareFrontend)
+		self.timer = eTimer()
+		self.timer.callback.append(self.updateFrontendStatus)
 
 	def openFrontend(self):
 		res_mgr = eDVBResourceManager.getInstance()
@@ -79,6 +81,15 @@ class Satfinder(ScanSetup, ServiceScan):
 						self.frontend = None # in normal case this should not happen
 		self.tuner = Tuner(self.frontend)
 		self.retune()
+
+	def updateFrontendStatus(self):
+		if self.frontend:
+			dict = {}
+			self.frontend.getFrontendStatus(dict)
+			if dict["tuner_state"] == "FAILED" or dict["tuner_state"] == "LOSTLOCK":
+				self.retune()
+			else:
+				self.timer.start(500, True)
 
 	def __onClose(self):
 		self.session.nav.playService(self.session.postScanService)
@@ -477,6 +488,7 @@ class Satfinder(ScanSetup, ServiceScan):
 			self.retuneCab()
 		elif self.DVB_type.value == "ATSC":
 			self.retuneATSC()
+		self.timer.start(500, True)
 
 	def keyGoScan(self):
 		self.frontend = None


### PR DESCRIPTION
Make the satfinder more robust by re-tuning in case of tune failure or
lock being lost.

Background:
eDVBChannel::frontendStateChanged() takes care of retuning managed
channels when a timeout occurs or lock is lost. For unmanaged channels
(such as Satfinder uses), clients should handle these situations
themselves.