### PR TITLE
[cablescan] do not start NIT/SDT filters until we have tuned

### DIFF
--- a/lib/dvb/cablescan.h
+++ b/lib/dvb/cablescan.h
@@ -24,6 +24,7 @@ class eCableScan: public sigc::trackable, public iObject
 	int initialModulation;
 	std::string providerName, bouquetFilename;
 	int networkId;
+	int tsId;
 	std::map<std::string, int> providerNames;
 
 	struct TransponderInfo
@@ -42,6 +43,10 @@ class eCableScan: public sigc::trackable, public iObject
 
 	ePtr<eTable<NetworkInformationSection> > m_NIT;
 	ePtr<eTable<ServiceDescriptionSection> > m_SDT;
+
+	int channelState;
+	ePtr<eConnection> stateChangedConnection;
+	void stateChanged(iDVBChannel *ch);
 
 	void NITReady(int error);
 	void SDTReady(int error);


### PR DESCRIPTION
We would risk getting an SDT timeout in particular (2500ms) because we
did not wait for the channel to have a lock before starting the SDT
reader.