### PR TITLE
zgemma box id and remotes (#2777)

### DIFF
--- a/data/rc_models/rc_models.cfg
+++ b/data/rc_models/rc_models.cfg
@@ -148,14 +148,17 @@ et10000.6       dmmadv
 # Zgemma
 i55             i55
 i55plus         zgemma
+i55se           zgemma
 h3              zgemma
 h4              zgemma
 h5              zgemma
 h6              zgemma
 h7              zgemma
 h9              zgemma
+h9se            zgemma
 h9combo         zgemma
-h9twin          zgemma
+h9combose       zgemma
+h10             zgemma
 lc              sh1
 sh1             sh1
 #

--- a/lib/python/Tools/HardwareInfo.py
+++ b/lib/python/Tools/HardwareInfo.py
@@ -4,6 +4,7 @@ hw_info = None
 
 class HardwareInfo:
 	device_name = _("unavailable")
+	device_brandname = None
 	device_model = None
 	device_version = ""
 	device_revision = ""
@@ -34,6 +35,12 @@ class HardwareInfo:
 		except:
 			pass
 
+		# Brandname ... bit odd, but history prevails
+		try:
+			self.device_brandname = open("/proc/stb/info/brandname").read().strip()
+		except:
+			pass
+
 		# Model
 		for line in open((resolveFilename(SCOPE_SKIN, 'hw_info/hw_info.cfg')), 'r'):
 			if not line.startswith('#') and not line.isspace():
@@ -51,6 +58,7 @@ class HardwareInfo:
 
 		# standard values
 		self.device_model = self.device_model or self.device_name
+		self.device_hw = self.device_model
 		self.machine_name = self.device_model
 
 		# custom overrides for specific receivers
@@ -58,21 +66,16 @@ class HardwareInfo:
 			self.machine_name = "%sx00" % self.device_model[:3]
 		elif self.device_model == "et11000":
 			self.machine_name = "et1x000"
-		elif self.device_model.startswith("H9 "):
-			self.device_name = self.device_model
-			self.device_model = self.device_name.replace(" ", "").lower()
-			self.machine_name = "h9combo"
-		elif self.device_model.startswith("H9"):
-			self.device_name = self.device_model
-			self.device_model = self.device_name.lower()
-			self.machine_name = "h9"
+		elif self.device_brandname == "Zgemma":
+			self.device_model = self.device_name
+			self.machine_name = self.device_name
 
 		if self.device_revision:
-			self.device_string = "%s (%s-%s)" % (self.device_model, self.device_revision, self.device_version)
+			self.device_string = "%s (%s-%s)" % (self.device_hw, self.device_revision, self.device_version)
 		elif self.device_version:
-			self.device_string = "%s (%s)" % (self.device_model, self.device_version)
+			self.device_string = "%s (%s)" % (self.device_hw, self.device_version)
 		else:
-			self.device_string = self.device_model
+			self.device_string = self.device_hw
 
 		# only some early DMM boxes do not have HDMI hardware
 		self.device_hdmi =  self.device_model not in ("dm800", "dm8000")


### PR DESCRIPTION
* add brandname proc
fix identifiction model/boxtype for zgemma hisilicon series

* add zgemma models: (i55se,h9se,h9combose,h10) remote info