### PR TITLE
epgcache: clear opentv eit map (#2795)

### DIFF
--- a/lib/dvb/epgcache.cpp
+++ b/lib/dvb/epgcache.cpp
@@ -2084,9 +2084,9 @@ void eEPGCache::channel_data::OPENTV_checkCompletion(uint32_t data_crc)
 				sids.push_back(m_OPENTV_channels_map[channelid].serviceId);
 				cache->submitEventData(sids, chids, it->second.startTime, it->second.duration, m_OPENTV_descriptors_map[it->second.title_crc].c_str(), "", "", 0, eEPGCache::OPENTV);
 			}
-			// m_OPENTV_EIT_map.erase(it); // removed for further testing due to seg fault, endless spinner and blocking issues
 		}
 		m_OPENTV_descriptors_map.clear();
+		m_OPENTV_EIT_map.clear();
 
 		if (++m_OPENTV_pid < 0x38)
 		{


### PR DESCRIPTION
clears residual data after each pid has been processed.

m_OPENTV_EIT_map.clear() replaces previously removed m_OPENTV_EIT_map.erase(it) with its missing sanity check