### PR TITLE
Fix tuners not going to sleep

### DIFF
--- a/lib/dvb/dvbtime.cpp
+++ b/lib/dvb/dvbtime.cpp
@@ -291,6 +291,8 @@ void eDVBLocalTimeHandler::setUseDVBTime(bool b)
 				eDebug("[eDVBLocalTimeHandler] invalid system time, refuse to disable transponder time sync");
 				return;
 			}
+			else
+				m_time_ready = true;
 		}
 		if (m_use_dvb_time) {
 			eDebug("[eDVBLocalTimeHandler] disable sync local time with transponder time!");


### PR DESCRIPTION
The reason was that E2 doesn't allow the tuners to sleep until we have a *DVB* time sync.
If we set time sync to use NTP however, that will *NEVER* happen.

This error always existed, but it was gone after a GUI restart, as then the initial "is now > 2004?" check was true and the sync was considered unnecessary.
We now consider it unnecessary, if the time is >2004 *AND* DVB time sync is disabled.

Merged from OpenATV: https://github.com/openatv/enigma2/commit/176f88bd9bdb5f9a53892dfff42466f72c26f025

Related commit: https://github.com/OpenViX/enigma2/commit/4903db3d9aa76f92b2c7e7c0ce341aaae6a07f77

Signed-off-by: Athanasios Oikonomou <athoik@gmail.com>