### PR TITLE
[opentv.cpp] Fix some spuriously timed EPG events (#659) (#2889)

### DIFF
--- a/lib/dvb/opentv.cpp
+++ b/lib/dvb/opentv.cpp
@@ -157,7 +157,13 @@ OpenTvTitle::OpenTvTitle(const uint8_t * const buffer, uint16_t startMjd)
 		uint8_t descriptor_length = buffer[1];
 		uint8_t titleLength = descriptor_length > 7 ? descriptor_length-7 : 0;
 
-		startTimeBcd = (((startMjd - 40587) * 86400) + (UINT16(&buffer[2]) << 1));
+		uint32_t startSecond = (UINT16(&buffer[2]) << 1);
+
+		startTimeBcd = ((startMjd - 40587) * 86400) + startSecond;
+		
+		if (startSecond >= 86400)
+			startTimeBcd -= 0x20000;
+		
 		duration = UINT16(&buffer[4]) << 1;
 
 		//genre content


### PR DESCRIPTION
Fix for occasional spurious events appearing 0x20000 seconds ahead of their correct position in the OpenTV EPG at certain times of the day.

Co-authored-by: Brian Gregory <bdgregory@gmail.com>