### PR TITLE
Add scale argument in loadSVG (#2903)

### DIFF
--- a/lib/gdi/epng.cpp
+++ b/lib/gdi/epng.cpp
@@ -362,14 +362,13 @@ static int savePNGto(FILE *fp, gPixmap *pixmap)
 	return 0;
 }
 
-int loadSVG(ePtr<gPixmap> &result, const char *filename, int cached, int width, int height)
+int loadSVG(ePtr<gPixmap> &result, const char *filename, int cached, int width, int height, float scale)
 {
 	result = nullptr;
 
 	if (cached && (result = PixmapCache::Get(filename)))
 		return 0;
 
-	// load svg
 	NSVGimage *image = nullptr;
 	NSVGrasterizer *rast = nullptr;
 	double xscale = 1.0;
@@ -402,6 +401,13 @@ int loadSVG(ePtr<gPixmap> &result, const char *filename, int cached, int width, 
 	{
 		xscale = yscale;
 		width = (int)(image->width * xscale);
+	}
+	else if (scale > 0)
+	{
+		xscale = (double) scale;
+		yscale = (double) scale;
+		width = (int)(image->width * scale);
+		height = (int)(image->height * scale);
 	}
 	else
 	{

--- a/lib/gdi/epng.h
+++ b/lib/gdi/epng.h
@@ -6,7 +6,7 @@
 SWIG_VOID(int) loadPNG(ePtr<gPixmap> &SWIG_OUTPUT, const char *filename, int accel = 0, int cached = 1);
 SWIG_VOID(int) loadJPG(ePtr<gPixmap> &SWIG_OUTPUT, const char *filename, int cached = 0);
 SWIG_VOID(int) loadJPG(ePtr<gPixmap> &SWIG_OUTPUT, const char *filename, ePtr<gPixmap> alpha, int cached = 0);
-SWIG_VOID(int) loadSVG(ePtr<gPixmap> &SWIG_OUTPUT, const char *filename, int cached = 0, int width = 0, int height = 0);
+SWIG_VOID(int) loadSVG(ePtr<gPixmap> &SWIG_OUTPUT, const char *filename, int cached = 0, int width = 0, int height = 0, float scale = 0);
 
 int savePNG(const char *filename, gPixmap *pixmap);
 


### PR DESCRIPTION
It allows scale image based on skin size without specifying the size of each image.
All necessary changes to ensure this will be implemented later.