### PR TITLE
[Satconfig]"Preferred tuner"- auto update tuners after save (#3047)

### DIFF
--- a/lib/python/Components/UsageConfig.py
+++ b/lib/python/Components/UsageConfig.py
@@ -257,43 +257,7 @@ def InitUsageConfig():
 
 	config.usage.show_timer_conflict_warning = ConfigYesNo(default=True)
 
-	dvbs_nims = [("-2", _("Disabled"))]
-	dvbt_nims = [("-2", _("Disabled"))]
-	dvbc_nims = [("-2", _("Disabled"))]
-	atsc_nims = [("-2", _("Disabled"))]
-
-	nims = [("-1", _("auto"))]
-	for x in nimmanager.nim_slots:
-		if x.isCompatible("DVB-S"):
-			dvbs_nims.append((str(x.slot), x.getSlotName()))
-		elif x.isCompatible("DVB-T"):
-			dvbt_nims.append((str(x.slot), x.getSlotName()))
-		elif x.isCompatible("DVB-C"):
-			dvbc_nims.append((str(x.slot), x.getSlotName()))
-		elif x.isCompatible("ATSC"):
-			atsc_nims.append((str(x.slot), x.getSlotName()))
-		nims.append((str(x.slot), x.getSlotName()))
-
-	config.usage.frontend_priority = ConfigSelection(default="-1", choices=list(nims))
-	nims.insert(0, ("-2", _("Disabled")))
-	config.usage.recording_frontend_priority = ConfigSelection(default="-2", choices=nims)
-	config.usage.frontend_priority_dvbs = ConfigSelection(default="-2", choices=list(dvbs_nims))
-	dvbs_nims.insert(1, ("-1", _("auto")))
-	config.usage.recording_frontend_priority_dvbs = ConfigSelection(default="-2", choices=dvbs_nims)
-	config.usage.frontend_priority_dvbt = ConfigSelection(default="-2", choices=list(dvbt_nims))
-	dvbt_nims.insert(1, ("-1", _("auto")))
-	config.usage.recording_frontend_priority_dvbt = ConfigSelection(default="-2", choices=dvbt_nims)
-	config.usage.frontend_priority_dvbc = ConfigSelection(default="-2", choices=list(dvbc_nims))
-	dvbc_nims.insert(1, ("-1", _("auto")))
-	config.usage.recording_frontend_priority_dvbc = ConfigSelection(default="-2", choices=dvbc_nims)
-	config.usage.frontend_priority_atsc = ConfigSelection(default="-2", choices=list(atsc_nims))
-	atsc_nims.insert(1, ("-1", _("auto")))
-	config.usage.recording_frontend_priority_atsc = ConfigSelection(default="-2", choices=atsc_nims)
-
-	SystemInfo["DVB-S_priority_tuner_available"] = len(dvbs_nims) > 3 and any(len(i) > 2 for i in (dvbt_nims, dvbc_nims, atsc_nims))
-	SystemInfo["DVB-T_priority_tuner_available"] = len(dvbt_nims) > 3 and any(len(i) > 2 for i in (dvbs_nims, dvbc_nims, atsc_nims))
-	SystemInfo["DVB-C_priority_tuner_available"] = len(dvbc_nims) > 3 and any(len(i) > 2 for i in (dvbs_nims, dvbt_nims, atsc_nims))
-	SystemInfo["ATSC_priority_tuner_available"] = len(atsc_nims) > 3 and any(len(i) > 2 for i in (dvbs_nims, dvbc_nims, dvbt_nims))
+	preferredTunerChoicesUpdate()
 
 	config.misc.disable_background_scan = ConfigYesNo(default=False)
 	config.misc.use_ci_assignment = ConfigYesNo(default=False)
@@ -881,3 +845,74 @@ def showrotorpositionChoicesUpdate(update=False):
 	else:
 		config.misc.showrotorposition.setChoices(choiceslist, "no")
 	SystemInfo["isRotorTuner"] = count > 0
+
+def preferredTunerChoicesUpdate(update=False):
+	dvbs_nims = [("-2", _("disabled"))]
+	dvbt_nims = [("-2", _("disabled"))]
+	dvbc_nims = [("-2", _("disabled"))]
+	atsc_nims = [("-2", _("disabled"))]
+
+	nims = [("-1", _("auto"))]
+	for slot in nimmanager.nim_slots:
+		if hasattr(slot.config, "configMode") and slot.config.configMode.value == "nothing":
+			continue
+		if slot.isCompatible("DVB-S"):
+			dvbs_nims.append((str(slot.slot), slot.getSlotName()))
+		elif slot.isCompatible("DVB-T"):
+			dvbt_nims.append((str(slot.slot), slot.getSlotName()))
+		elif slot.isCompatible("DVB-C"):
+			dvbc_nims.append((str(slot.slot), slot.getSlotName()))
+		elif slot.isCompatible("ATSC"):
+			atsc_nims.append((str(slot.slot), slot.getSlotName()))
+		nims.append((str(slot.slot), slot.getSlotName()))
+
+	if not update:
+		config.usage.frontend_priority = ConfigSelection(default="-1", choices=list(nims))
+	else:
+		cconfig.usage.frontend_priority.setChoices(list(nims), "-1")
+	nims.insert(0, ("-2", _("disabled")))
+	if not update:
+		config.usage.recording_frontend_priority = ConfigSelection(default="-2", choices=nims)
+	else:
+		config.usage.recording_frontend_priority.setChoices(nims, "-2")
+	if not update:
+		config.usage.frontend_priority_dvbs = ConfigSelection(default="-2", choices=list(dvbs_nims))
+	else:
+		config.usage.frontend_priority_dvbs.setChoices(list(dvbs_nims), "-2")
+	dvbs_nims.insert(1, ("-1", _("auto")))
+	if not update:
+		config.usage.recording_frontend_priority_dvbs = ConfigSelection(default="-2", choices=dvbs_nims)
+	else:
+		config.usage.recording_frontend_priority_dvbs.setChoices(dvbs_nims, "-2")
+	if not update:
+		config.usage.frontend_priority_dvbt = ConfigSelection(default="-2", choices=list(dvbt_nims))
+	else:
+		config.usage.frontend_priority_dvbt.setChoices(list(dvbt_nims), "-2")
+	dvbt_nims.insert(1, ("-1", _("auto")))
+	if not update:
+		config.usage.recording_frontend_priority_dvbt = ConfigSelection(default="-2", choices=dvbt_nims)
+	else:
+		config.usage.recording_frontend_priority_dvbt.setChoices(dvbt_nims, "-2")
+	if not update:
+		config.usage.frontend_priority_dvbc = ConfigSelection(default="-2", choices=list(dvbc_nims))
+	else:
+		config.usage.frontend_priority_dvbc.setChoices(list(dvbc_nims), "-2")
+	dvbc_nims.insert(1, ("-1", _("auto")))
+	if not update:
+		config.usage.recording_frontend_priority_dvbc = ConfigSelection(default="-2", choices=dvbc_nims)
+	else:
+		config.usage.recording_frontend_priority_dvbc.setChoices(dvbc_nims, "-2")
+	if not update:
+		config.usage.frontend_priority_atsc = ConfigSelection(default="-2", choices=list(atsc_nims))
+	else:
+		config.usage.frontend_priority_atsc.setChoices(list(atsc_nims), "-2")
+	atsc_nims.insert(1, ("-1", _("auto")))
+	if not update:
+		config.usage.recording_frontend_priority_atsc = ConfigSelection(default="-2", choices=atsc_nims)
+	else:
+		config.usage.recording_frontend_priority_atsc.setChoices(atsc_nims, "-2")
+
+	SystemInfo["DVB-S_priority_tuner_available"] = len(dvbs_nims) > 3 and any(len(i) > 2 for i in (dvbt_nims, dvbc_nims, atsc_nims))
+	SystemInfo["DVB-T_priority_tuner_available"] = len(dvbt_nims) > 3 and any(len(i) > 2 for i in (dvbs_nims, dvbc_nims, atsc_nims))
+	SystemInfo["DVB-C_priority_tuner_available"] = len(dvbc_nims) > 3 and any(len(i) > 2 for i in (dvbs_nims, dvbt_nims, atsc_nims))
+	SystemInfo["ATSC_priority_tuner_available"] = len(atsc_nims) > 3 and any(len(i) > 2 for i in (dvbs_nims, dvbc_nims, dvbt_nims))

--- a/lib/python/Screens/Satconfig.py
+++ b/lib/python/Screens/Satconfig.py
@@ -6,7 +6,7 @@ from Components.ConfigList import ConfigListScreen
 from Components.NimManager import nimmanager
 from Components.Button import Button
 from Components.Label import Label
-from Components.UsageConfig import showrotorpositionChoicesUpdate
+from Components.UsageConfig import showrotorpositionChoicesUpdate, preferredTunerChoicesUpdate
 from Components.SelectionList import SelectionList, SelectionEntryComponent
 from Components.config import getConfigListEntry, config, ConfigNothing, ConfigYesNo, configfile, ConfigBoolean, ConfigSelection
 from Components.Sources.List import List
@@ -207,7 +207,10 @@ class NimSetup(Screen, ConfigListScreen, ServiceStopScreen):
 				self.configModeDVBC = getConfigListEntry(_("Configure DVB-C"), self.nimConfig.configModeDVBC, _("Select 'Yes' when you want to configure this tuner for DVB-C"))
 				self.list.append(self.configModeDVBC)
 			elif not self.nim.isMultiType():
-				self.configMode = getConfigListEntry(self.indent % _("Configuration mode"), self.nimConfig.configMode, _("Select 'enabled' if this tuner has a signal cable connected, otherwise select 'nothing connected'."))
+				warning_text = ""
+				if "Vuplus DVB-C NIM(BCM3148)" in self.nim.description and self.nim.isFBCRoot() and self.nim.is_fbc[2] != 1:
+					warning_text = _("Warning: FBC-C V1 tuner should be connected to the first slot to work correctly. Otherwise, only 2 out of 8 demodulators will be available when connected in the second slot. ")
+				self.configMode = getConfigListEntry(self.indent % _("Configuration mode"), self.nimConfig.configMode, warning_text + _("Select 'enabled' if this tuner has a signal cable connected, otherwise select 'nothing connected'."))
 				self.list.append(self.configMode)
 			if self.nimConfig.configModeDVBC.value if self.nim.isCombined() else self.nimConfig.configMode.value != "nothing":
 				self.list.append(getConfigListEntry(self.indent % _("Network ID"), self.nimConfig.cable.scan_networkid, _("This setting depends on your cable provider and location. If you don't know the correct setting refer to the menu in the official cable receiver, or get it from your cable provider, or seek help via internet forum.")))
@@ -691,6 +694,7 @@ class NimSetup(Screen, ConfigListScreen, ServiceStopScreen):
 				x[1].save()
 			configfile.save()
 		showrotorpositionChoicesUpdate(update=True)
+		preferredTunerChoicesUpdate(update=True)
 
 	def cancelConfirm(self, result):
 		if not result:


### PR DESCRIPTION
* [Satconfig]"Preferred tuner"- auto update tuners after save

-[Satconfig] add warning text for FBC-C ver.1:
One FBC tuner supports 8 demodulators. Two slots make it 16 demodulators
totally.

Slot A : FBC DVB-S2X, FBC-C V1/V2 and Dual T2(MTISF) Tuner
Slot B : FBC DVB-S2X, FBC-C V2 and Dual T2(MTISF) Tuner

* FBC-C V1 Tuner can only be connected to slot A.