### PR TITLE
[dvb] fix alignment on time-based seek

### DIFF
--- a/lib/dvb/dvb.cpp
+++ b/lib/dvb/dvb.cpp
@@ -2050,7 +2050,7 @@ void eDVBChannel::getNextSourceSpan(off_t current_offset, size_t bytes_read, off
 			{
 					/* in normal playback, just start at the next zone. */
 				start = i->first;
-				size = diff_upto(i->second, start, max);
+				size = align(diff_upto(i->second, start, max), blocksize);
 				eDebug("[eDVBChannel] skip");
 				if (m_skipmode_m < 0)
 				{


### PR DESCRIPTION
When navigating through dvb data, size and pointers should always be alligned on blocksize. This fix takes care of that when seeking on timestamp (for example by the cut list editor), so misalignment crashes can be avoided (like filepush.cpp:70 ASSERTION !(current_span_remaining % m_blocksize) FAILED!)